### PR TITLE
add issuer and audience cause another api do not have permissions

### DIFF
--- a/Tamagotchi.Authorization/Helpers/JwtHelper.cs
+++ b/Tamagotchi.Authorization/Helpers/JwtHelper.cs
@@ -10,11 +10,13 @@ namespace Tamagotchi.Authorization.Helpers
     {
         public static string GenerateToken(int userId, string secretKey, int lifeTime)
         {
-            var claims = new[] { new Claim("user_id", userId.ToString(), ClaimValueTypes.Integer) };
+            var claims = new[] { new Claim("user_id", $"{userId}", ClaimValueTypes.Integer) };
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey));
-            var signInCredential = new SigningCredentials(key, "HS256");
+            var signInCredential = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
             var dateNow = DateTime.UtcNow;
             var token = new JwtSecurityToken(
+                issuer: "tama.gotchi",
+                audience: "tama.gotchi",
                 notBefore: dateNow,
                 expires: dateNow.Add(TimeSpan.FromHours(lifeTime)),
                 claims: claims,

--- a/Tamagotchi.Authorization/Startup.cs
+++ b/Tamagotchi.Authorization/Startup.cs
@@ -1,10 +1,13 @@
 ﻿
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
 using Swashbuckle.AspNetCore.Swagger;
+using System.Text;
 using Tamagotchi.Authorization.Core;
 using Tamagotchi.Authorization.Models;
 
@@ -28,6 +31,20 @@ namespace Tamagotchi.Authorization
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = "tama.gotchi",
+                    ValidAudience = "tama.gotchi",
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Configuration.GetSection("AppInfo:SecretKey").Value))
+                };
+            });
             services.AddDbContext<UserContext>(options =>
                 options.UseNpgsql(Configuration.GetConnectionString("LocalDB")));
             services.AddScoped<IConfirmationCodeRepository, ConfirmationCodeRepository>();


### PR DESCRIPTION
Задача: https://github.com/tamagochy/tamagotchi/issues/35

Само приложение настроено, чтобы сгенерировать токен по некоторым правилам, но если попытаться повесить атрибут [Authorize] на какой-то открытый Action и указать в хедерах токен, то оно не поймет, что пользователь атворизован и выкинет 401 код. Чтобы исправить это, нужно в middleware слое сконфигурировать схему аутентификации вот так:
```
services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
            .AddJwtBearer(options =>
            {
                options.TokenValidationParameters = new TokenValidationParameters
                {
                    ValidateIssuer = true,
                    ValidateAudience = true,
                    ValidateLifetime = true,
                    ValidateIssuerSigningKey = true,
                    ValidIssuer = "tama.gotchi",
                    ValidAudience = "tama.gotchi",
                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Configuration.GetSection("AppInfo:SecretKey").Value))
                };
            });
```

Здесь также нужно учесть тот факт, что любое другое API не сможет понять, что это за токен пришел, поэтому выкинет 401 код, если не указать **ISSUER** и **AUDIENCE** , что соответствует издателю токена и его потребителю, в качестве решения я захардкоженную строку использовал. В остальном все ок.
![image](https://user-images.githubusercontent.com/15847375/49896014-27568880-fe63-11e8-90ba-bf615e816587.png)
